### PR TITLE
Add persistent whisper listener support

### DIFF
--- a/command.py
+++ b/command.py
@@ -37,6 +37,8 @@ def register_all_commands(bot):
     bot.register_command(commands('joinme'), cmd_joinme, access_outside_channel=True)
     bot.register_command(commands('last'), cmd_last)
     bot.register_command(commands('list_file'), cmd_list_file)
+    bot.register_command(commands('listen'), cmd_listen)
+    bot.register_command(commands('unlisten'), cmd_unlisten)
     bot.register_command(commands('mode'), cmd_mode)
     bot.register_command(commands('pause'), cmd_pause)
     bot.register_command(commands('play'), cmd_play)
@@ -147,6 +149,22 @@ def cmd_joinme(bot, user, text, command, parameter):
 
     bot.mumble.users.myself.move_in(
         bot.mumble.users[text.actor]['channel_id'], token=parameter)
+
+
+def cmd_listen(bot, user, text, command, parameter):
+    if user not in bot.listen_subscribers:
+        bot.listen_subscribers.add(user)
+        var.db.set("whisper_subscribe", user, "1")
+        bot.update_whisper_sessions()
+    bot.send_msg(tr('listen_on'), text)
+
+
+def cmd_unlisten(bot, user, text, command, parameter):
+    if user in bot.listen_subscribers:
+        bot.listen_subscribers.remove(user)
+        var.db.remove_option("whisper_subscribe", user)
+        bot.update_whisper_sessions()
+    bot.send_msg(tr('listen_off'), text)
 
 
 def cmd_user_ban(bot, user, text, command, parameter):

--- a/configuration.default.ini
+++ b/configuration.default.ini
@@ -157,4 +157,6 @@ version = version
 volume = volume
 yt_play = yplay
 yt_search = ysearch
+listen = listen, l
+unlisten = unlisten, u
 

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -91,7 +91,9 @@
         "wrong_pattern": "Invalid regex: {error}.",
         "yt_no_more": "No more results!",
         "yt_query_error": "Unable to query youtube!",
-        "yt_result": "Youtube query result: {result_table} Use <i>!sl {{indexes}}</i> to play the item you want. <br />\n<i>!ytquery -n</i> for the next page."
+        "yt_result": "Youtube query result: {result_table} Use <i>!sl {{indexes}}</i> to play the item you want. <br />\n<i>!ytquery -n</i> for the next page.",
+        "listen_on": "Whisper subscription enabled.",
+        "listen_off": "Whisper subscription disabled."
     },
     "web": {
         "action": "Action",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ Pillow
 mutagen
 requests
 packaging
-pymumble>=1.2
+pymumble>=1.7
 pyradios


### PR DESCRIPTION
## Summary
- add `listen` and `unlisten` commands
- load whisper listeners from DB and keep sessions updated
- send channel messages directly to listeners
- ignore empty channel pause when listeners are online
- provide translated messages for subscribing

## Testing
- `python3 -m py_compile mumbleBot.py command.py interface.py util.py database.py variables.py`