### PR TITLE
Add podman-compose config

### DIFF
--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -114,10 +114,12 @@ class MumbleBot:
         else:
             self.bandwidth = var.config.getint("bot", "bandwidth")
 
+        # client_type=1 marks this connection as a bot for servers supporting it
         self.mumble = pymumble.Mumble(host, user=self.username, port=port, password=password, tokens=tokens,
                                       stereo=self.stereo,
                                       debug=var.config.getboolean('debug', 'mumble_connection'),
-                                      certfile=certificate)
+                                      certfile=certificate,
+                                      client_type=1)
         self.mumble.callbacks.set_callback(pymumble.constants.PYMUMBLE_CLBK_TEXTMESSAGERECEIVED, self.message_received)
 
         self.mumble.set_codec_profile("audio")

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -1,0 +1,38 @@
+version: "3.9"
+
+services:
+  botamusique:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: botamusique:latest
+    container_name: botamusique
+    restart: unless-stopped
+    security_opt:
+      - label=disable
+    expose:
+      - "8181"
+    environment:
+      # Connect to the host's Murmur server via Podman host gateway
+      - BAM_MUMBLE_SERVER=host.containers.internal
+      # Store the SQLite databases on a writable host mount
+      - BAM_DB=/data/settings.db
+      - BAM_MUSIC_DB=/data/music.db
+    volumes:
+      # Custom configuration to enable web interface
+      - ./configuration.ini:/botamusique/configuration.ini:Z
+      # Persist databases
+      - ./data:/data:Z
+    networks:
+      - proxy
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.botamusique.rule: "Host(`mumblemusic.skyn3t.lol`)"
+      traefik.http.routers.botamusique.entrypoints: "websecure"
+      traefik.http.routers.botamusique.tls: "true"
+      traefik.http.services.botamusique.loadbalancer.server.port: "8181"
+
+networks:
+  proxy:
+    external:
+      name: proxy

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ Pillow
 mutagen
 requests
 packaging
-pymumble>=1.2
+pymumble>=1.7
 pyradios


### PR DESCRIPTION
## Summary
- provide a basic podman-compose.yml to run the bot with Podman and Traefik

## Testing
- `python3 -m py_compile mumbleBot.py command.py interface.py util.py database.py variables.py`
