### PR TITLE
Update pymumble requirement and provide fallback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ Pillow
 mutagen
 requests
 packaging
-pymumble>=1.7
+pymumble>=1.6.1
 pyradios


### PR DESCRIPTION
## Summary
- pin pymumble to 1.6.1 since 1.7 isn't available
- add compatibility for older pymumble versions by handling missing parameters

## Testing
- `python3 -m py_compile command.py mumbleBot.py interface.py util.py database.py constants.py variables.py`
