### PR TITLE
Monkey patch pymumble for client_type support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ Pillow
 mutagen
 requests
 packaging
-pymumble>=1.7
+pymumble>=1.6.1
 pyradios


### PR DESCRIPTION
## Summary
- monkey patch pymumble to accept `client_type` when the library doesn't
- always pass `client_type=1` during connection

## Testing
- `python3 -m py_compile command.py mumbleBot.py interface.py util.py database.py constants.py variables.py`
