### PR TITLE
Fix whisper sessions after listener reconnect

### DIFF
--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -230,12 +230,12 @@ class MumbleBot:
         assert var.config.get("bot", "when_nobody_in_channel") in ['pause', 'pause_resume', 'stop', 'nothing', ''], \
             "Unknown action for when_nobody_in_channel"
 
-        if var.config.get("bot", "when_nobody_in_channel") in ['pause', 'pause_resume', 'stop']:
-            user_change_callback = \
-                lambda user, action: threading.Thread(target=self.users_changed,
-                                                      args=(user, action), daemon=True).start()
-            self.mumble.callbacks.set_callback(pymumble.constants.PYMUMBLE_CLBK_USERREMOVED, user_change_callback)
-            self.mumble.callbacks.set_callback(pymumble.constants.PYMUMBLE_CLBK_USERUPDATED, user_change_callback)
+        # Always track user changes so whisper sessions stay updated after a listener reconnects
+        user_change_callback = \
+            lambda user, action: threading.Thread(target=self.users_changed,
+                                                  args=(user, action), daemon=True).start()
+        self.mumble.callbacks.set_callback(pymumble.constants.PYMUMBLE_CLBK_USERREMOVED, user_change_callback)
+        self.mumble.callbacks.set_callback(pymumble.constants.PYMUMBLE_CLBK_USERUPDATED, user_change_callback)
 
         # Debug use
         self._loop_status = 'Idle'


### PR DESCRIPTION
## Summary
- update `mumbleBot` to always register callbacks for user changes

This ensures whisper targets are refreshed whenever listeners reconnect, preventing silent playback if `!listen` was used earlier.

## Testing
- `python -m py_compile mumbleBot.py command.py interface.py util.py variables.py constants.py database.py`